### PR TITLE
Create Bucket 操作を Refactoring

### DIFF
--- a/api/models/logger_tool.py
+++ b/api/models/logger_tool.py
@@ -12,13 +12,14 @@ logging.basicConfig(filename=Path(f"{const.LOGFILE_PATH}{const.LOG_FILE}"), leve
 logger = logging.getLogger(__name__)
 
 
-def error(action, status, bucket_name: str, ex):
+def error(action, status, bucket_name: str, ex, msg=None):
     logger.error({
         'time': time.datetime_now(),
         'action': action,
         'status': status,
         'bucket name': bucket_name,
         'except': ex,
+        'msg': msg,
     })
 
 

--- a/config/const.py
+++ b/config/const.py
@@ -1,18 +1,20 @@
-LOGFILE_PATH = 'log/'
-LOG_FILE = 'bucket.log'
-TMP_PATH = 'tmp/'
-
+# DB ---------------
 DB_NAME = 'user'
 TABLE_NAME = 'user'
 INSERT_RECODE_NUM = 10
 
-BUCKET_CREATE = 0
+# AWS --------------
+CLIENT = 's3'
+BUCKET_NAME = 'testbucket-yyyymmdd'
+TOKYO_REGION = 'ap-northeast-1'
+
+LOGFILE_PATH = 'log/'
+LOG_FILE = 'bucket.log'
+TMP_PATH = 'tmp/'
+
+BUCKET_CREATE = 1
 BUCKET_DELETE = 1
 
-UPLOAD = 0
+UPLOAD = 1
 DOWNLOAD = 0
 DELETE = 1
-
-CLIENT = 's3'
-BUCKET_NAME = 'testbucket-0911-2'
-TOKYO_REGION = 'ap-northeast-1'


### PR DESCRIPTION
## About
- タイトル通り

## Task
- `is_bucket_check`関数を削除し、`BucketAlreadyExists` を採用
- `const.py` の並びを調整
- `logger_tool` の error に `msg`を追加

## Reference
* [Catching exceptions when using a resource client](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#catching-exceptions-when-using-a-resource-client)